### PR TITLE
Fix JsonProperty names for player starting positions

### DIFF
--- a/Data/RPGSystem.cs
+++ b/Data/RPGSystem.cs
@@ -466,6 +466,7 @@ namespace MVDeserializer.Data
 					value.HitRate,
 					value.EvasionRate
 				};
+				serializer.Serialize(writer, toList);
 			}
 		}
 	}

--- a/Data/RPGSystem.cs
+++ b/Data/RPGSystem.cs
@@ -664,13 +664,13 @@ namespace MVDeserializer.Data
 
 		#region Starting Positions
 
-		[JsonProperty("startMapId")]
+		[JsonProperty("startId")]
 		public int StartMapId { get; set; }
 
-		[JsonProperty("startMapX")]
+		[JsonProperty("startX")]
 		public int StartMapX { get; set; }
 
-		[JsonProperty("startMapY")]
+		[JsonProperty("startY")]
 		public int StartMapY { get; set; }
 
 		#endregion Starting Positions

--- a/MVData.cs
+++ b/MVData.cs
@@ -62,7 +62,7 @@ namespace MVDeserializer
 			foreach (string filePath in Directory.GetFiles(dataPath))
 			{
 				string fileName = Path.GetFileName(filePath);
-				if (!fileName.StartsWith("Map") || fileName.StartsWith("MapI"))
+				if (!fileName.StartsWith("Map") || fileName.StartsWith("MapI") || fileName.StartsWith("MapH"))
 				{
 					continue;
 				}


### PR DESCRIPTION
startMapX should be startX. startMapY should be startY. RPGSystem was getting 0 for both of them every time.